### PR TITLE
`Users`: set up registration server-side

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -2,6 +2,7 @@ import cors from "cors";
 import "dotenv/config";
 import express, { RequestHandler } from "express";
 import { indexRouter } from "./src/routers/index-router";
+import { userRouter } from "./src/routers/user/user-router";
 
 /** Configure Express server and start listening for requests. */
 async function startServer() {
@@ -25,6 +26,7 @@ async function startServer() {
    app.use(express.json() as RequestHandler);
 
    app.use("/", indexRouter);
+   app.use("/user", userRouter);
 
    const port = process.env.PORT || 5000;
 

--- a/server/src/routers/user/get-user.test.ts
+++ b/server/src/routers/user/get-user.test.ts
@@ -1,6 +1,6 @@
 import { UserInput } from "../../../types/user.types";
 import { sqlConnection } from "../../db/init";
-import { getUser } from "./get-user";
+import { getUser, userExists } from "./get-user";
 import { insertUser } from "./register";
 
 describe("getUser", () => {
@@ -27,6 +27,23 @@ describe("getUser", () => {
          const shouldBeUndefined = await getUser({ sql, username: `${Math.random()}` });
 
          expect(shouldBeUndefined).toBeUndefined();
+
+         sql`rollback`;
+      });
+   });
+});
+
+describe("userExists", () => {
+   it("returns true for existing user, false for nonexistent user", async () => {
+      const user: UserInput = {
+         username: `${Math.random()}`,
+         password_hash: "1",
+      };
+      sqlConnection.begin(async (sql) => {
+         await insertUser({ sql, userInput: user });
+
+         expect(userExists({ sql, username: user.username })).toBeTruthy();
+         expect(userExists({ sql, username: `${Math.random()}` })).toBeFalsy();
 
          sql`rollback`;
       });

--- a/server/src/routers/user/get-user.test.ts
+++ b/server/src/routers/user/get-user.test.ts
@@ -1,0 +1,34 @@
+import { UserInput } from "../../../types/user.types";
+import { sqlConnection } from "../../db/init";
+import { getUser } from "./get-user";
+import { insertUser } from "./register";
+
+describe("getUser", () => {
+   it("returns a just-inserted user", async () => {
+      sqlConnection.begin(async (sql) => {
+         const newUser: UserInput = {
+            username: "Billy",
+            password_hash: "this should really be a hash",
+         };
+
+         await insertUser({ sql, userInput: newUser });
+
+         const foundUser = await getUser({ sql, username: newUser.username });
+
+         expect(foundUser?.username).toEqual(newUser.username);
+         expect(foundUser?.password_hash).toEqual(newUser.password_hash);
+
+         sql`rollback`;
+      });
+   });
+
+   it("does not return a user that doesn't exist", async () => {
+      sqlConnection.begin(async (sql) => {
+         const shouldBeUndefined = await getUser({ sql, username: `${Math.random()}` });
+
+         expect(shouldBeUndefined).toBeUndefined();
+
+         sql`rollback`;
+      });
+   });
+});

--- a/server/src/routers/user/get-user.ts
+++ b/server/src/routers/user/get-user.ts
@@ -1,0 +1,28 @@
+import { WithSQL } from "../../../types/sql.types";
+import { User } from "../../../types/user.types";
+import { sqlConnection } from "../../db/init";
+
+/** Check if there is a user with the given `username`. */
+export async function userExists({
+   sql = sqlConnection,
+   username,
+}: WithSQL<{ username: string }>) {
+   const [user] = await sql<[User?]>`select * from users where username = ${username}`;
+
+   return !!user?.username;
+}
+
+/** Get a user by `user_id` or `username`. */
+export async function getUser({
+   sql = sqlConnection,
+   username,
+   user_id,
+}: WithSQL<{ username?: string; user_id?: number }>) {
+   if (!username && !user_id) return;
+
+   const [user] = await sql<[User?]>`select * from users where ${
+      user_id ? sql`user_id = ${user_id}` : sql`username = ${username ?? null}`
+   }`;
+
+   return user;
+}

--- a/server/src/routers/user/register.ts
+++ b/server/src/routers/user/register.ts
@@ -7,7 +7,7 @@ import { userExists } from "./get-user";
 /** Parse a raw NewUser (presumably from the client) to a UserInput for database
  * insertion. */
 export async function parseNewUserForDatabase(newUser: NewUser): Promise<UserInput> {
-   const hashedPassword = await hash(newUser.password, 22);
+   const hashedPassword = await hash(newUser.password, 11);
 
    const parsedNewUser: UserInput = {
       username: newUser.username,
@@ -27,7 +27,7 @@ export async function insertUser({
 
       const [insertedUser] = await q<[User?]>`
          insert into users 
-         (username, password) ${q(userInput)}
+         ${q(userInput)}
          returning *
       `;
 

--- a/server/src/routers/user/register.ts
+++ b/server/src/routers/user/register.ts
@@ -1,0 +1,31 @@
+import { hash } from "bcryptjs";
+import { WithSQL } from "../../../types/sql.types";
+import { NewUser, User, UserInput } from "../../../types/user.types";
+import { sqlConnection } from "../../db/init";
+
+/** Parse a raw NewUser (presumably from the client) to a UserInput for database
+ * insertion. */
+export async function parseNewUserForDatabase(newUser: NewUser): Promise<UserInput> {
+   const hashedPassword = await hash(newUser.password, 22);
+
+   const parsedNewUser: UserInput = {
+      username: newUser.username,
+      password_hash: hashedPassword,
+   };
+
+   return parsedNewUser;
+}
+
+/** Inserts a UserInput object into the database and returns the inserted user. */
+export async function insertUser({
+   sql = sqlConnection,
+   userInput,
+}: WithSQL<{ userInput: UserInput }>) {
+   const [insertedUser] = await sql<[User?]>`
+      insert into users 
+      (username, password) ${sql(userInput)}
+      returning *
+   `;
+
+   return insertedUser;
+}

--- a/server/src/routers/user/user-router.ts
+++ b/server/src/routers/user/user-router.ts
@@ -1,12 +1,16 @@
 import { Router } from "express";
-import { NewUser } from "../../../types/user.types";
+import { isNewUser } from "../../../types/user.types";
 import { userExists } from "./get-user";
 import { insertUser, parseNewUserForDatabase } from "./register";
 
 export const userRouter = Router({ mergeParams: true });
 
 userRouter.post("/register", async (req, res) => {
-   const newUser: NewUser = req.body.newUser;
+   const newUser: any = req.body.newUser;
+
+   if (!isNewUser(newUser)) {
+      res.status(400).json({ message: "Invalid `newUser` in request body." });
+   }
 
    // This check is also done inside `insertUser`, but this way it's easiest to
    // send the correct response type without complicating `insertUser`

--- a/server/src/routers/user/user-router.ts
+++ b/server/src/routers/user/user-router.ts
@@ -8,6 +8,8 @@ export const userRouter = Router({ mergeParams: true });
 userRouter.post("/register", async (req, res) => {
    const newUser: NewUser = req.body.newUser;
 
+   // This check is also done inside `insertUser`, but this way it's easiest to
+   // send the correct response type without complicating `insertUser`
    if (await userExists({ username: newUser.username }))
       res.status(403).json({ message: "Username already taken." });
 

--- a/server/src/routers/user/user-router.ts
+++ b/server/src/routers/user/user-router.ts
@@ -9,17 +9,17 @@ userRouter.post("/register", async (req, res) => {
    const newUser: any = req.body.newUser;
 
    if (!isNewUser(newUser)) {
-      res.status(400).json({ message: "Invalid `newUser` in request body." });
+      return res.status(400).json({ message: "Invalid `newUser` in request body." });
    }
 
    // This check is also done inside `insertUser`, but this way it's easiest to
    // send the correct response type without complicating `insertUser`
    if (await userExists({ username: newUser.username }))
-      res.status(403).json({ message: "Username already taken." });
+      return res.status(403).json({ message: "Username already taken." });
 
    const insertedUser = await insertUser({
       userInput: await parseNewUserForDatabase(newUser),
    });
 
-   res.status(201).json({ user: insertedUser });
+   return res.status(201).json({ user: insertedUser });
 });

--- a/server/src/routers/user/user-router.ts
+++ b/server/src/routers/user/user-router.ts
@@ -1,0 +1,19 @@
+import { Router } from "express";
+import { NewUser } from "../../../types/user.types";
+import { userExists } from "./get-user";
+import { insertUser, parseNewUserForDatabase } from "./register";
+
+export const userRouter = Router({ mergeParams: true });
+
+userRouter.post("/register", async (req, res) => {
+   const newUser: NewUser = req.body.newUser;
+
+   if (await userExists({ username: newUser.username }))
+      res.status(403).json({ message: "Username already taken." });
+
+   const insertedUser = await insertUser({
+      userInput: await parseNewUserForDatabase(newUser),
+   });
+
+   res.status(201).json({ user: insertedUser });
+});

--- a/server/types/user.types.ts
+++ b/server/types/user.types.ts
@@ -1,0 +1,16 @@
+export type NewUser = {
+   password: string;
+   repeatPassword: string;
+   username: string;
+};
+
+export type UserInput = {
+   password_hash: string;
+   username: string;
+};
+
+// Corresponds to `users` table in the database.
+export interface User extends UserInput {
+   user_id: number;
+   created_at: number;
+}

--- a/server/types/user.types.ts
+++ b/server/types/user.types.ts
@@ -14,3 +14,7 @@ export interface User extends UserInput {
    user_id: number;
    created_at: number;
 }
+
+export function isNewUser(newUser: any): newUser is NewUser {
+   return typeof newUser.username === "string" && typeof newUser.password === "string";
+}


### PR DESCRIPTION
Part of #3.

# Changes:
- [x] implement `user` and `newUser` related types
- [x] implement various queries (fetch a user, check if a username is taken)
- [x] implement function to parse `NewUser` to `UserInput` for database insertion (generates a hashed password)
- [x] implement register INSERT query
- [x] implement userRouter with /register POST endpoint to handle the registration